### PR TITLE
Allow nametags to prevent werepyr villagers from despawning

### DIFF
--- a/src/main/java/dev/mrsterner/besmirchment/common/entity/WerepyreEntity.java
+++ b/src/main/java/dev/mrsterner/besmirchment/common/entity/WerepyreEntity.java
@@ -134,7 +134,7 @@ public class WerepyreEntity extends BWHostileEntity {
             }
         }
 
-        if (spawnReason == SpawnReason.NATURAL) {
+        if (spawnReason == SpawnReason.NATURAL || spawnReason == SpawnReason.SPAWN_EGG) {
             storedVillager = EntityType.VILLAGER.create((World) world).writeNbt(new NbtCompound());
         }
         return data;
@@ -157,12 +157,18 @@ public class WerepyreEntity extends BWHostileEntity {
     public void readCustomDataFromNbt(NbtCompound tag) {
         super.readCustomDataFromNbt(tag);
         setLastJumpTime(tag.getInt("LastJumpTicks"));
+        if (tag.contains("StoredVillager")) {
+            storedVillager = tag.getCompound("StoredVillager");
+        }
     }
 
 
     public void writeCustomDataToNbt(NbtCompound tag) {
         super.writeCustomDataToNbt(tag);
         tag.putInt("LastJumpTicks", getLastJumpTime());
+        if (storedVillager != null) {
+            tag.put("StoredVillager", storedVillager);
+        }
     }
 
     @Override
@@ -234,4 +240,6 @@ public class WerepyreEntity extends BWHostileEntity {
             setVelocity(vec3d2.x, vec3d2.y, vec3d2.z);
         }
     }
+
+
 }

--- a/src/main/java/dev/mrsterner/besmirchment/mixin/VillagerEntityMixin.java
+++ b/src/main/java/dev/mrsterner/besmirchment/mixin/VillagerEntityMixin.java
@@ -51,13 +51,13 @@ public abstract class VillagerEntityMixin extends MerchantEntity implements Vill
     @Inject(method = "tick", at = @At("TAIL"))
     private void tick(CallbackInfo callbackInfo) {
         if (!world.isClient && storedWerepyre != null) {
-            if (despawnTimer > 0) {
+            if (!this.hasCustomName() && despawnTimer > 0) {
                 despawnTimer--;
                 if (despawnTimer == 0) {
                     remove(RemovalReason.DISCARDED);
                 }
             }
-            if (age % 20 == 0 && world.isNight() && BewitchmentAPI.getMoonPhase(world) == 0 && world.isSkyVisible(getBlockPos())) {
+            if (age % 20 == 0 && world.isNight() && BewitchmentAPI.getMoonPhase(world) == 0 && (this.hasCustomName() || this.world.isSkyVisible(this.getBlockPos()))) {
                 WerepyreEntity entity = BSMEntityTypes.WEREPYRE.create(world);
                 if (entity != null) {
                     PlayerLookup.tracking(this).forEach(player -> SpawnSmokeParticlesPacket.send(player, this));
@@ -70,7 +70,7 @@ public abstract class VillagerEntityMixin extends MerchantEntity implements Vill
                     getStatusEffects().forEach(entity::addStatusEffect);
                     BWComponents.CURSES_COMPONENT.get(entity).getCurses().clear();
                     BWComponents.CURSES_COMPONENT.get(this).getCurses().forEach((BWComponents.CURSES_COMPONENT.get(entity))::addCurse);
-                    if (despawnTimer >= 0) {
+                    if (!entity.hasCustomName() && despawnTimer >= 0) {
                         despawnTimer = 2400;
                     }
                     entity.storedVillager = writeNbt(new NbtCompound());


### PR DESCRIPTION
VillagerEntityMixin, add checks for a custom name before setting and acting upon the despawn timer
VillagerEntityMixin, add a check for custom name to cause tagged werepyre to transform even if not exposed to direct moon light, this one might be slightly out of scope but allows for more interesting uses for tagged werepyre.
**WerepyreEntity**, save stored villager to nbt
**WerepyreEntity**, create a stored villager when using a spawn egg, mostly QoL for testing the above patches

This PR is based on a similar pull for Betwitchment werewolves, See https://github.com/MoriyaShiine/bewitchment/pull/356 